### PR TITLE
Integrating KRC reservoir data API

### DIFF
--- a/APItoDB_WAMIS/MainFrm.Designer.cs
+++ b/APItoDB_WAMIS/MainFrm.Designer.cs
@@ -27,6 +27,14 @@
             this.lblStartDate = new System.Windows.Forms.Label();
             this.lblEndDate = new System.Windows.Forms.Label();
             this._chkTestMode = new System.Windows.Forms.CheckBox();
+            this.groupBoxKRC = new System.Windows.Forms.GroupBox();
+            this._btnKrcFetchAllCodes = new System.Windows.Forms.Button();
+            this._btnKrcInitialLoad = new System.Windows.Forms.Button();
+            this._btnKrcDailyUpdate = new System.Windows.Forms.Button();
+            this._btnKrcBackfill = new System.Windows.Forms.Button();
+            this.groupBoxWamis = new System.Windows.Forms.GroupBox();
+            this.groupBoxKRC.SuspendLayout();
+            this.groupBoxWamis.SuspendLayout();
             this.SuspendLayout();
             // 
             // _dtpStartDate
@@ -35,25 +43,25 @@
             this._dtpStartDate.Location = new System.Drawing.Point(78, 15);
             this._dtpStartDate.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this._dtpStartDate.Name = "_dtpStartDate";
-            this._dtpStartDate.Size = new System.Drawing.Size(228, 25);
+            this._dtpStartDate.Size = new System.Drawing.Size(190, 25);
             this._dtpStartDate.TabIndex = 0;
             this._dtpStartDate.Value = new System.DateTime(1990, 1, 1, 0, 0, 0, 0);
             // 
             // _dtpEndDate
             // 
             this._dtpEndDate.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            this._dtpEndDate.Location = new System.Drawing.Point(384, 15);
+            this._dtpEndDate.Location = new System.Drawing.Point(346, 15);
             this._dtpEndDate.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this._dtpEndDate.Name = "_dtpEndDate";
-            this._dtpEndDate.Size = new System.Drawing.Size(228, 25);
+            this._dtpEndDate.Size = new System.Drawing.Size(190, 25);
             this._dtpEndDate.TabIndex = 1;
             // 
             // _btnInitialLoad
             // 
-            this._btnInitialLoad.Location = new System.Drawing.Point(14, 62);
+            this._btnInitialLoad.Location = new System.Drawing.Point(10, 25);
             this._btnInitialLoad.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this._btnInitialLoad.Name = "_btnInitialLoad";
-            this._btnInitialLoad.Size = new System.Drawing.Size(171, 38);
+            this._btnInitialLoad.Size = new System.Drawing.Size(140, 38);
             this._btnInitialLoad.TabIndex = 2;
             this._btnInitialLoad.Text = "초기 데이터 로드";
             this._btnInitialLoad.UseVisualStyleBackColor = true;
@@ -61,10 +69,10 @@
             // 
             // _btnDailyUpdate
             // 
-            this._btnDailyUpdate.Location = new System.Drawing.Point(194, 62);
+            this._btnDailyUpdate.Location = new System.Drawing.Point(156, 25);
             this._btnDailyUpdate.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this._btnDailyUpdate.Name = "_btnDailyUpdate";
-            this._btnDailyUpdate.Size = new System.Drawing.Size(171, 38);
+            this._btnDailyUpdate.Size = new System.Drawing.Size(140, 38);
             this._btnDailyUpdate.TabIndex = 3;
             this._btnDailyUpdate.Text = "일별 최신화";
             this._btnDailyUpdate.UseVisualStyleBackColor = true;
@@ -72,10 +80,10 @@
             // 
             // _btnBackfill
             // 
-            this._btnBackfill.Location = new System.Drawing.Point(375, 62);
+            this._btnBackfill.Location = new System.Drawing.Point(302, 25);
             this._btnBackfill.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this._btnBackfill.Name = "_btnBackfill";
-            this._btnBackfill.Size = new System.Drawing.Size(171, 38);
+            this._btnBackfill.Size = new System.Drawing.Size(140, 38);
             this._btnBackfill.TabIndex = 4;
             this._btnBackfill.Text = "누락 데이터 보충";
             this._btnBackfill.UseVisualStyleBackColor = true;
@@ -86,13 +94,13 @@
             this._txtLogs.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._txtLogs.Location = new System.Drawing.Point(14, 112);
+            this._txtLogs.Location = new System.Drawing.Point(14, 160);
             this._txtLogs.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this._txtLogs.Multiline = true;
             this._txtLogs.Name = "_txtLogs";
             this._txtLogs.ReadOnly = true;
             this._txtLogs.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this._txtLogs.Size = new System.Drawing.Size(868, 524);
+            this._txtLogs.Size = new System.Drawing.Size(868, 476);
             this._txtLogs.TabIndex = 5;
             // 
             // _progressBar
@@ -119,7 +127,7 @@
             // lblEndDate
             // 
             this.lblEndDate.AutoSize = true;
-            this.lblEndDate.Location = new System.Drawing.Point(320, 19);
+            this.lblEndDate.Location = new System.Drawing.Point(282, 19);
             this.lblEndDate.Name = "lblEndDate";
             this.lblEndDate.Size = new System.Drawing.Size(57, 15);
             this.lblEndDate.TabIndex = 8;
@@ -135,25 +143,91 @@
             this._chkTestMode.Text = "테스트 모드";
             this._chkTestMode.UseVisualStyleBackColor = true;
             // 
-            // Form1
+            // groupBoxKRC
+            //
+            this.groupBoxKRC.Controls.Add(this._btnKrcBackfill);
+            this.groupBoxKRC.Controls.Add(this._btnKrcDailyUpdate);
+            this.groupBoxKRC.Controls.Add(this._btnKrcInitialLoad);
+            this.groupBoxKRC.Controls.Add(this._btnKrcFetchAllCodes);
+            this.groupBoxKRC.Location = new System.Drawing.Point(14, 100);
+            this.groupBoxKRC.Name = "groupBoxKRC";
+            this.groupBoxKRC.Size = new System.Drawing.Size(868, 53);
+            this.groupBoxKRC.TabIndex = 11;
+            this.groupBoxKRC.TabStop = false;
+            this.groupBoxKRC.Text = "KRC 농업용 저수지";
+            //
+            // _btnKrcFetchAllCodes
+            //
+            this._btnKrcFetchAllCodes.Location = new System.Drawing.Point(10, 20);
+            this._btnKrcFetchAllCodes.Name = "_btnKrcFetchAllCodes";
+            this._btnKrcFetchAllCodes.Size = new System.Drawing.Size(140, 28);
+            this._btnKrcFetchAllCodes.TabIndex = 0;
+            this._btnKrcFetchAllCodes.Text = "전체 코드 조회/저장";
+            this._btnKrcFetchAllCodes.UseVisualStyleBackColor = true;
+            this._btnKrcFetchAllCodes.Click += new System.EventHandler(this.BtnKrcFetchAllCodes_Click);
+            //
+            // _btnKrcInitialLoad
+            //
+            this._btnKrcInitialLoad.Location = new System.Drawing.Point(156, 20);
+            this._btnKrcInitialLoad.Name = "_btnKrcInitialLoad";
+            this._btnKrcInitialLoad.Size = new System.Drawing.Size(140, 28);
+            this._btnKrcInitialLoad.TabIndex = 1;
+            this._btnKrcInitialLoad.Text = "초기 수위 로드";
+            this._btnKrcInitialLoad.UseVisualStyleBackColor = true;
+            this._btnKrcInitialLoad.Click += new System.EventHandler(this.BtnKrcInitialLoad_Click);
+            //
+            // _btnKrcDailyUpdate
+            //
+            this._btnKrcDailyUpdate.Location = new System.Drawing.Point(302, 20);
+            this._btnKrcDailyUpdate.Name = "_btnKrcDailyUpdate";
+            this._btnKrcDailyUpdate.Size = new System.Drawing.Size(140, 28);
+            this._btnKrcDailyUpdate.TabIndex = 2;
+            this._btnKrcDailyUpdate.Text = "수위 일별 최신화";
+            this._btnKrcDailyUpdate.UseVisualStyleBackColor = true;
+            this._btnKrcDailyUpdate.Click += new System.EventHandler(this.BtnKrcDailyUpdate_Click);
+            //
+            // _btnKrcBackfill
+            //
+            this._btnKrcBackfill.Location = new System.Drawing.Point(448, 20);
+            this._btnKrcBackfill.Name = "_btnKrcBackfill";
+            this._btnKrcBackfill.Size = new System.Drawing.Size(140, 28);
+            this._btnKrcBackfill.TabIndex = 3;
+            this._btnKrcBackfill.Text = "수위 누락 보충";
+            this._btnKrcBackfill.UseVisualStyleBackColor = true;
+            this._btnKrcBackfill.Click += new System.EventHandler(this.BtnKrcBackfill_Click);
+            //
+            // groupBoxWamis
+            //
+            this.groupBoxWamis.Controls.Add(this._btnInitialLoad);
+            this.groupBoxWamis.Controls.Add(this._btnDailyUpdate);
+            this.groupBoxWamis.Controls.Add(this._btnBackfill);
+            this.groupBoxWamis.Location = new System.Drawing.Point(14, 45);
+            this.groupBoxWamis.Name = "groupBoxWamis";
+            this.groupBoxWamis.Size = new System.Drawing.Size(868, 52);
+            this.groupBoxWamis.TabIndex = 12;
+            this.groupBoxWamis.TabStop = false;
+            this.groupBoxWamis.Text = "WAMIS 수자원";
+            //
+            // MainFrm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(896, 701);
+            this.Controls.Add(this.groupBoxWamis);
+            this.Controls.Add(this.groupBoxKRC);
             this.Controls.Add(this._chkTestMode);
             this.Controls.Add(this.lblEndDate);
             this.Controls.Add(this.lblStartDate);
             this.Controls.Add(this._progressBar);
             this.Controls.Add(this._txtLogs);
-            this.Controls.Add(this._btnBackfill);
-            this.Controls.Add(this._btnDailyUpdate);
-            this.Controls.Add(this._btnInitialLoad);
             this.Controls.Add(this._dtpEndDate);
             this.Controls.Add(this._dtpStartDate);
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "Form1";
+            this.Name = "MainFrm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "WAMIS 데이터 수집기";
+            this.Text = "데이터 수집기 (WAMIS & KRC)";
+            this.groupBoxKRC.ResumeLayout(false);
+            this.groupBoxWamis.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -171,5 +245,11 @@
         private System.Windows.Forms.Label lblStartDate;
         private System.Windows.Forms.Label lblEndDate;
         private System.Windows.Forms.CheckBox _chkTestMode;
+        private System.Windows.Forms.GroupBox groupBoxKRC;
+        private System.Windows.Forms.Button _btnKrcBackfill;
+        private System.Windows.Forms.Button _btnKrcDailyUpdate;
+        private System.Windows.Forms.Button _btnKrcInitialLoad;
+        private System.Windows.Forms.Button _btnKrcFetchAllCodes;
+        private System.Windows.Forms.GroupBox groupBoxWamis;
     }
 }

--- a/APItoDB_WAMIS/MainFrm.cs
+++ b/APItoDB_WAMIS/MainFrm.cs
@@ -11,7 +11,12 @@ namespace WamisDataCollector
     public partial class MainFrm : Form
     {
         private readonly Wamis_DataSyncService _syncService;
-        private static readonly ILog log = LogManager.GetLogger(typeof(MainFrm)); 
+        private static readonly ILog log = LogManager.GetLogger(typeof(MainFrm));
+
+        // KRC Services
+        private KrcReservoirService _krcReservoirService;
+        private KrcDataService _krcDataService;
+        private Wamis_DataService _wamisDataService; // For KRC station codes and last dates
 
         public MainFrm()
         {
@@ -19,23 +24,20 @@ namespace WamisDataCollector
 
             try
             {
-                var apiKey = ConfigurationManager.AppSettings["WamisApiKey"];
-                var baseUrl = ConfigurationManager.AppSettings["WamisBaseUrl"];
+                // WAMIS Services
+                var wamisApiKey = ConfigurationManager.AppSettings["WamisApiKey"];
+                var wamisBaseUrl = ConfigurationManager.AppSettings["WamisBaseUrl"];
                 var connectionString = ConfigurationManager.ConnectionStrings["PostgreSqlConnection"].ConnectionString;
 
                 var missingSettings = new List<string>();
-                if (string.IsNullOrEmpty(apiKey))
-                {
-                    missingSettings.Add("WamisApiKey");
-                }
-                if (string.IsNullOrEmpty(baseUrl))
-                {
-                    missingSettings.Add("WamisBaseUrl");
-                }
-                if (string.IsNullOrEmpty(connectionString))
-                {
-                    missingSettings.Add("PostgreSqlConnection");
-                }
+                if (string.IsNullOrEmpty(wamisApiKey)) missingSettings.Add("WamisApiKey");
+                if (string.IsNullOrEmpty(wamisBaseUrl)) missingSettings.Add("WamisBaseUrl");
+                if (string.IsNullOrEmpty(connectionString)) missingSettings.Add("PostgreSqlConnection");
+
+                // KRC Services
+                var krcApiKey = ConfigurationManager.AppSettings["KrcApiKey"];
+                if (string.IsNullOrEmpty(krcApiKey)) missingSettings.Add("KrcApiKey");
+
 
                 if (missingSettings.Count > 0)
                 {
@@ -43,14 +45,24 @@ namespace WamisDataCollector
                     throw new InvalidOperationException(errorMessage);
                 }
 
-                var apiClient = new Wamis_ApiClient(apiKey, baseUrl, this.Log);
-                var dataService = new Wamis_DataService(connectionString, this.Log);
-                _syncService = new Wamis_DataSyncService(apiClient, dataService, this.Log, log);
+                var apiClient = new Wamis_ApiClient(wamisApiKey, wamisBaseUrl, this.Log);
+                _wamisDataService = new Wamis_DataService(connectionString, this.Log); // Reused for KRC needs
+                _syncService = new Wamis_DataSyncService(apiClient, _wamisDataService, this.Log, log);
+
+                // Initialize KRC Services
+                // Assuming KrcReservoirService needs HttpClient. For simplicity, creating a new one.
+                // In a more complex app, HttpClient might be managed centrally.
+                var httpClientForKrc = new System.Net.Http.HttpClient();
+                _krcReservoirService = new KrcReservoirService(httpClientForKrc); // Pass krcApiKey if constructor takes it, or it reads from config
+                _krcDataService = new KrcDataService(connectionString, this.Log);
+
+                // Ensure KRC tables exist
+                Task.Run(async () => await _wamisDataService.EnsureTablesExistAsync()).Wait(); // Ensure krc_reservoir_daily is created
             }
             catch (Exception ex)
             {
-                log.Fatal("설정 파일 로드 중 심각한 오류 발생", ex); 
-                MessageBox.Show($"설정 파일(App.config) 로드 중 오류가 발생했습니다: {ex.Message}", "오류", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                log.Fatal("설정 파일 로드 또는 서비스 초기화 중 심각한 오류 발생", ex);
+                MessageBox.Show($"설정 파일(App.config) 로드 또는 서비스 초기화 중 오류가 발생했습니다: {ex.Message}", "오류", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Environment.Exit(1);
             }
         }
@@ -120,7 +132,36 @@ namespace WamisDataCollector
             _btnBackfill.Enabled = enabled;
             _dtpStartDate.Enabled = enabled;
             _dtpEndDate.Enabled = enabled;
+            _chkTestMode.Enabled = enabled;
+
+            // WAMIS buttons
+            _btnInitialLoad.Enabled = enabled;
+            _btnDailyUpdate.Enabled = enabled;
+            _btnBackfill.Enabled = enabled;
+
+            // KRC buttons
+            _btnKrcFetchAllCodes.Enabled = enabled;
+            _btnKrcInitialLoad.Enabled = enabled;
+            _btnKrcDailyUpdate.Enabled = enabled;
+            _btnKrcBackfill.Enabled = enabled;
+
+            _progressBar.Style = enabled ? ProgressBarStyle.Continuous : ProgressBarStyle.Marquee;
             _progressBar.MarqueeAnimationSpeed = enabled ? 0 : 100;
+            if (enabled) _progressBar.Value = 0;
+        }
+
+        private void UpdateProgressBar(int currentValue, int maxValue)
+        {
+            if (this.InvokeRequired)
+            {
+                this.Invoke(new Action<int, int>(UpdateProgressBar), currentValue, maxValue);
+                return;
+            }
+            if (maxValue > 0)
+            {
+                _progressBar.Maximum = maxValue;
+                _progressBar.Value = Math.Min(currentValue, maxValue);
+            }
         }
 
         private void Log(string message)
@@ -131,6 +172,213 @@ namespace WamisDataCollector
                 return;
             }
             _txtLogs.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}");
+        }
+
+        // KRC Button Handlers
+        private async void BtnKrcFetchAllCodes_Click(object sender, EventArgs e)
+        {
+            if (MessageBox.Show("KRC 전체 저수지 코드를 조회하여 DB에 저장/업데이트합니다. 계속하시겠습니까?",
+                                "KRC 코드 전체 조회",
+                                MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            {
+                await RunTask(async () =>
+                {
+                    Log("KRC 전체 저수지 코드 조회를 시작합니다...");
+                    var allCodes = new List<WamisWaterLevelDataApi.Models.KrcReservoirCodeItem>();
+                    int pageNo = 1;
+                    int totalCount = 0;
+                    const int numOfRows = 100; // API가 허용하는 최대치 또는 적절한 값으로 설정
+
+                    do
+                    {
+                        Log($"KRC 저수지 코드 조회 중 (페이지: {pageNo})...");
+                        var response = await _krcReservoirService.GetReservoirCodesAsync(numOfRows: numOfRows, pageNo: pageNo);
+                        if (response?.Body?.Items != null && response.Body.Items.Any())
+                        {
+                            allCodes.AddRange(response.Body.Items);
+                            totalCount = response.Body.TotalCount; // 첫 페이지에서 전체 개수 확인
+                            Log($"{response.Body.Items.Count}개 코드 수신 (누적: {allCodes.Count} / 전체 예상: {totalCount})");
+                        }
+                        else
+                        {
+                            Log("더 이상 조회할 코드가 없거나 API 응답에 오류가 있습니다.");
+                            break;
+                        }
+                        pageNo++;
+                    } while (allCodes.Count < totalCount);
+
+                    Log($"총 {allCodes.Count}개의 KRC 저수지 코드 정보 수집 완료. DB에 저장합니다...");
+                    await _krcDataService.UpsertKrcReservoirStationsAsync(allCodes);
+                    Log("KRC 저수지 코드 정보 DB 저장 완료.");
+                });
+            }
+        }
+
+        private async void BtnKrcInitialLoad_Click(object sender, EventArgs e)
+        {
+            await CollectKrcLevelDataAsync("KRC 수위 초기 데이터 로드",
+                (facCode, dateS, dateE, county, numOfRows, pageNo, isTestMode)
+                => _krcReservoirService.GetReservoirLevelsForInitialSetupAsync(facCode, dateS, dateE, county, numOfRows, pageNo, isTestMode));
+        }
+
+        private async void BtnKrcDailyUpdate_Click(object sender, EventArgs e)
+        {
+            bool isTestMode = _chkTestMode.Checked;
+            if (MessageBox.Show($"KRC 저수지 수위 데이터를 최신 정보로 업데이트합니다.{(isTestMode ? " (테스트 모드)" : "")}",
+                                $"KRC 수위 일별 최신화{(isTestMode ? " (테스트)" : "")}",
+                                MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            {
+                await RunTask(async () =>
+                {
+                    Log("KRC 저수지 수위 일별 최신화를 시작합니다...");
+                    var krcStations = await _wamisDataService.GetAllStationsAsync("KRC_RESERVOIR");
+                    if (krcStations == null || !krcStations.Any())
+                    {
+                        Log("DB에 KRC 저수지 정보가 없습니다. 먼저 'KRC 전체 코드 조회/저장'을 실행하세요.");
+                        return;
+                    }
+
+                    Log($"총 {krcStations.Count}개의 KRC 저수지에 대해 일별 최신화를 진행합니다.");
+
+                    for (int i = 0; i < krcStations.Count; i++)
+                    {
+                        var station = krcStations[i];
+                        Log($"({i + 1}/{krcStations.Count}) 저수지 코드: {station.StationCode} ({station.Name}) 최신화 중...");
+
+                        try
+                        {
+                            DateTime? lastDate = await _wamisDataService.GetLastKrcReservoirDailyDateAsync(station.StationCode);
+                            string startDateForApi;
+                            if (lastDate.HasValue)
+                            {
+                                startDateForApi = lastDate.Value.AddDays(1).ToString("yyyyMMdd");
+                            }
+                            else // DB에 데이터가 전혀 없는 경우 (초기 로드 안된 상태)
+                            {
+                                // 기본적으로는 어제부터 오늘까지 (또는 설정된 기본 시작일부터)
+                                // 여기서는 메시지를 남기고 건너뛰거나, 특정 기간으로 초기 로드를 유도할 수 있음
+                                // 또는, 오늘 하루치만 가져오도록 할 수도 있음.
+                                // 우선은 오늘 하루치만 가져오도록 처리
+                                Log($"{station.StationCode}: DB에 저장된 데이터가 없어 오늘({DateTime.Now:yyyyMMdd}) 데이터를 수집합니다. 전체 기간 데이터는 '초기 수위 로드'를 이용하세요.");
+                                startDateForApi = DateTime.Now.ToString("yyyyMMdd");
+                            }
+
+                            string endDateForApi = DateTime.Now.ToString("yyyyMMdd");
+
+                            if (Convert.ToDateTime(startDateForApi) > Convert.ToDateTime(endDateForApi))
+                            {
+                                Log($"{station.StationCode}: 이미 최신 데이터입니다 (마지막 저장일: {lastDate?.ToString("yyyy-MM-dd")}).");
+                                continue;
+                            }
+
+                            var levelResponse = await _krcReservoirService.UpdateReservoirLevelsAsync(
+                                station.StationCode, lastDate.HasValue ? lastDate.Value.ToString("yyyyMMdd") : DateTime.Now.AddDays(-1).ToString("yyyyMMdd"), // Update uses last saved date string
+                                isTestMode: isTestMode);
+
+                            if (levelResponse?.Body?.Items != null && levelResponse.Body.Items.Any())
+                            {
+                                Log($"{station.StationCode}: {levelResponse.Body.Items.Count}개 업데이트 데이터 수신. DB에 저장합니다.");
+                                await _krcDataService.BulkUpsertKrcReservoirDailyDataAsync(levelResponse.Body.Items);
+                            }
+                            else
+                            {
+                                Log($"{station.StationCode}: 업데이트할 새로운 수위 데이터가 없습니다.");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log($"[오류] 저수지 코드 {station.StationCode} 최신화 중 오류: {ex.Message}");
+                            log.Error($"KRC 수위 일별 최신화 중 오류 (Station: {station.StationCode})", ex);
+                        }
+                        UpdateProgressBar(i + 1, krcStations.Count);
+                    }
+                    Log("KRC 저수지 수위 일별 최신화 완료.");
+                });
+            }
+        }
+
+        private async void BtnKrcBackfill_Click(object sender, EventArgs e)
+        {
+            // KRC 수위 누락 데이터 보충 로직 (BtnKrcInitialLoad_Click과 유사하게 구현됨)
+            await CollectKrcLevelDataAsync("KRC 수위 누락 데이터 보충",
+                (facCode, dateS, dateE, county, numOfRows, pageNo, isTestMode)
+                => _krcReservoirService.GetReservoirLevelsForInitialSetupAsync(facCode, dateS, dateE, county, numOfRows, pageNo, isTestMode));
+        }
+
+        /// <summary>
+        /// KRC 저수지 수위 데이터를 수집하고 DB에 저장하는 공통 로직. (초기 로드 및 누락 데이터 보충용)
+        /// </summary>
+        /// <param name="taskTitle">작업 제목 (로그용)</param>
+        /// <param name="apiCallFunc">실제 API를 호출하는 함수 (facCode, dateS, dateE, county, numOfRows, pageNo, isTestMode 파라미터를 받고 Task<KrcReservoirLevelResponse> 반환)</param>
+        private async Task CollectKrcLevelDataAsync(string taskTitle,
+            Func<string, string, string, string, int, int, bool, Task<WamisWaterLevelDataApi.Models.KrcReservoirLevelResponse>> apiCallFunc)
+        {
+            var startDate = _dtpStartDate.Value;
+            var endDate = _dtpEndDate.Value;
+            bool isTestMode = _chkTestMode.Checked;
+
+            if (MessageBox.Show($"{startDate:yyyy-MM-dd}부터 {endDate:yyyy-MM-dd}까지의 {taskTitle}을(를) {(isTestMode ? "테스트 모드로 " : "")}시작합니다. 계속하시겠습니까?",
+                                $"{taskTitle}{(isTestMode ? " (테스트)" : "")}",
+                                MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            {
+                await RunTask(async () =>
+                {
+                    Log($"{taskTitle}을(를) 시작합니다...");
+                    var krcStations = await _wamisDataService.GetAllStationsAsync("KRC_RESERVOIR");
+                    if (krcStations == null || !krcStations.Any())
+                    {
+                        Log("DB에 KRC 저수지 정보가 없습니다. 먼저 'KRC 전체 코드 조회/저장'을 실행하세요.");
+                        return;
+                    }
+
+                    Log($"총 {krcStations.Count}개의 KRC 저수지에 대해 {taskTitle}을(를) 진행합니다.");
+
+                    for (int i = 0; i < krcStations.Count; i++)
+                    {
+                        var station = krcStations[i];
+                        DateTime currentStartDate = startDate;
+
+                        while (currentStartDate <= endDate)
+                        {
+                            DateTime currentEndDate = currentStartDate.AddDays(365 -1); // KRC API 최대 조회 기간 365일
+                            if (currentEndDate > endDate)
+                            {
+                                currentEndDate = endDate;
+                            }
+
+                            string dateS = currentStartDate.ToString("yyyyMMdd");
+                            string dateE = currentEndDate.ToString("yyyyMMdd");
+
+                            Log($"({i + 1}/{krcStations.Count}) 저수지 코드: {station.StationCode} ({station.Name}) 데이터 수집 중... ({dateS}~{dateE})");
+
+                            try
+                            {
+                                // KRC API는 최대 365일까지 한번에 조회 가능. numOfRows는 충분히 크게 설정.
+                                var levelResponse = await apiCallFunc(
+                                    station.StationCode, dateS, dateE, null, 366, 1, isTestMode);
+
+                                if (levelResponse?.Body?.Items != null && levelResponse.Body.Items.Any())
+                                {
+                                    Log($"{station.StationCode}: {levelResponse.Body.Items.Count}개 데이터 수신. DB에 저장합니다.");
+                                    await _krcDataService.BulkUpsertKrcReservoirDailyDataAsync(levelResponse.Body.Items);
+                                }
+                                else
+                                {
+                                    Log($"{station.StationCode} ({dateS}~{dateE}): 해당 기간에 조회된 수위 데이터가 없습니다.");
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Log($"[오류] 저수지 코드 {station.StationCode} ({dateS}~{dateE}) 데이터 수집 중 오류: {ex.Message}");
+                                log.Error($"{taskTitle} 중 오류 (Station: {station.StationCode}, Period: {dateS}~{dateE})", ex);
+                            }
+                            currentStartDate = currentEndDate.AddDays(1);
+                        }
+                        UpdateProgressBar(i + 1, krcStations.Count);
+                    }
+                    Log($"{taskTitle} 완료.");
+                });
+            }
         }
     }
 }

--- a/APItoDB_WAMIS/W_Services/Wamis_DataService.cs
+++ b/APItoDB_WAMIS/W_Services/Wamis_DataService.cs
@@ -37,6 +37,16 @@ namespace WamisDataCollector.Services
                 // 수위
                 await new NpgsqlCommand(@"CREATE TABLE IF NOT EXISTS wl_hourly (station_code TEXT NOT NULL, obs_time TIMESTAMP NOT NULL, water_level REAL, PRIMARY KEY (station_code, obs_time));", conn).ExecuteNonQueryAsync();
                 await new NpgsqlCommand(@"CREATE TABLE IF NOT EXISTS wl_daily (station_code TEXT NOT NULL, obs_date DATE NOT NULL, water_level REAL, PRIMARY KEY (station_code, obs_date));", conn).ExecuteNonQueryAsync();
+
+                // KRC 저수지 수위/저수율 (일별 데이터만 존재)
+                await new NpgsqlCommand(@"CREATE TABLE IF NOT EXISTS krc_reservoir_daily (
+                    station_code TEXT NOT NULL,
+                    obs_date DATE NOT NULL,
+                    water_level REAL,
+                    rate REAL,
+                    PRIMARY KEY (station_code, obs_date)
+                );", conn).ExecuteNonQueryAsync();
+
                 // 기상
                 await new NpgsqlCommand(@"CREATE TABLE IF NOT EXISTS weather_hourly (
                     station_code TEXT NOT NULL, obs_time TIMESTAMP NOT NULL, ta REAL, hm REAL, td REAL, ps REAL, ws REAL, wd TEXT, sihr1 REAL, catot REAL, sdtot REAL, sshr1 REAL, PRIMARY KEY (station_code, obs_time) );", conn).ExecuteNonQueryAsync();
@@ -687,6 +697,10 @@ namespace WamisDataCollector.Services
         public async Task<DateTime?> GetLastMonthlyRainfallDateAsync(string stationCode) => await GetLastDateAsync("rf_monthly", "obs_month", "station_code", stationCode);
         public async Task<DateTime?> GetLastWaterLevelHourlyDateAsync(string stationCode) => await GetLastDateAsync("wl_hourly", "obs_time", "station_code", stationCode);
         public async Task<DateTime?> GetLastDailyWaterLevelDateAsync(string stationCode) => await GetLastDateAsync("wl_daily", "obs_date", "station_code", stationCode);
+
+        // KRC 저수지 데이터용 마지막 날짜 조회
+        public async Task<DateTime?> GetLastKrcReservoirDailyDateAsync(string stationCode) => await GetLastDateAsync("krc_reservoir_daily", "obs_date", "station_code", stationCode);
+
         public async Task<DateTime?> GetLastWeatherHourlyDateAsync(string stationCode) => await GetLastDateAsync("weather_hourly", "obs_time", "station_code", stationCode);
         public async Task<DateTime?> GetLastWeatherDailyDateAsync(string stationCode) => await GetLastDateAsync("weather_daily", "obs_date", "station_code", stationCode);
         public async Task<DateTime?> GetLastFlowMeasurementDateAsync(string stationCode) => await GetLastDateAsync("flow_measurements", "obs_date", "station_code", stationCode);

--- a/APItoDB_WAMIS/config/App.config
+++ b/APItoDB_WAMIS/config/App.config
@@ -5,6 +5,7 @@
     </startup>
 	<appSettings>
 		<add key="WamisApiKey" value="aa" />
+		<add key="KrcApiKey" value="YOUR_KRC_API_KEY_HERE" /> <!-- KRC API 키 추가 -->
 		<add key="WamisBaseUrl" value="http://www.wamis.go.kr:8080/wamis/openapi" />
 	</appSettings>
 	<connectionStrings>

--- a/Models/krc_ErrorResponse.cs
+++ b/Models/krc_ErrorResponse.cs
@@ -1,0 +1,27 @@
+using System.Xml.Serialization;
+
+namespace WamisWaterLevelDataApi.Models
+{
+    [XmlRoot("OpenAPI_ServiceResponse")]
+    public class KrcOpenApiErrorResponse
+    {
+        [XmlElement("cmmMsgHeader")]
+        public KrcCmmMsgHeader CmmMsgHeader { get; set; }
+    }
+
+    public class KrcCmmMsgHeader
+    {
+        [XmlElement("errMsg")]
+        public string ErrMsg { get; set; }
+
+        [XmlElement("returnAuthMsg")]
+        public string ReturnAuthMsg { get; set; }
+
+        [XmlElement("returnReasonCode")]
+        public string ReturnReasonCode { get; set; }
+    }
+
+    // For provider errors (non-OpenAPI portal errors), the structure is similar to normal responses' header.
+    // We can reuse KrcHeader or define a specific one if needed.
+    // For now, assuming provider errors might also use a similar structure or be identified by returnReasonCode in KrcHeader.
+}

--- a/Models/krc_ReservoirCode.cs
+++ b/Models/krc_ReservoirCode.cs
@@ -1,0 +1,52 @@
+using System.Xml.Serialization;
+using System.Collections.Generic;
+
+namespace WamisWaterLevelDataApi.Models
+{
+    [XmlRoot("response")]
+    public class KrcReservoirCodeResponse
+    {
+        [XmlElement("header")]
+        public KrcHeader Header { get; set; }
+
+        [XmlElement("body")]
+        public KrcReservoirCodeBody Body { get; set; }
+    }
+
+    public class KrcHeader
+    {
+        [XmlElement("returnReasonCode")]
+        public string ReturnReasonCode { get; set; }
+
+        [XmlElement("returnAuthMsg")]
+        public string ReturnAuthMsg { get; set; }
+    }
+
+    public class KrcReservoirCodeBody
+    {
+        [XmlArray("items")]
+        [XmlArrayItem("item")]
+        public List<KrcReservoirCodeItem> Items { get; set; }
+
+        [XmlElement("numOfRows")]
+        public int NumOfRows { get; set; }
+
+        [XmlElement("pageNo")]
+        public int PageNo { get; set; }
+
+        [XmlElement("totalCount")]
+        public int TotalCount { get; set; }
+    }
+
+    public class KrcReservoirCodeItem
+    {
+        [XmlElement("fac_code")]
+        public string FacCode { get; set; }
+
+        [XmlElement("fac_name")]
+        public string FacName { get; set; }
+
+        [XmlElement("county")]
+        public string County { get; set; }
+    }
+}

--- a/Models/krc_ReservoirLevel.cs
+++ b/Models/krc_ReservoirLevel.cs
@@ -1,0 +1,52 @@
+using System.Xml.Serialization;
+using System.Collections.Generic;
+
+namespace WamisWaterLevelDataApi.Models
+{
+    [XmlRoot("response")]
+    public class KrcReservoirLevelResponse
+    {
+        [XmlElement("header")]
+        public KrcHeader Header { get; set; } // Reusing KrcHeader from KrcReservoirCode.cs
+
+        [XmlElement("body")]
+        public KrcReservoirLevelBody Body { get; set; }
+    }
+
+    public class KrcReservoirLevelBody
+    {
+        [XmlArray("items")]
+        [XmlArrayItem("item")]
+        public List<KrcReservoirLevelItem> Items { get; set; }
+
+        [XmlElement("numOfRows")]
+        public int NumOfRows { get; set; }
+
+        [XmlElement("pageNo")]
+        public int PageNo { get; set; }
+
+        [XmlElement("totalCount")]
+        public int TotalCount { get; set; }
+    }
+
+    public class KrcReservoirLevelItem
+    {
+        [XmlElement("fac_code")]
+        public string FacCode { get; set; }
+
+        [XmlElement("fac_name")]
+        public string FacName { get; set; }
+
+        [XmlElement("county")]
+        public string County { get; set; }
+
+        [XmlElement("check_date")]
+        public string CheckDate { get; set; } // YYYYMMDD
+
+        [XmlElement("water_level")]
+        public string WaterLevel { get; set; } // string to handle potential non-numeric values before parsing
+
+        [XmlElement("rate")]
+        public string Rate { get; set; } // string to handle potential non-numeric values before parsing
+    }
+}

--- a/Services/krc_DataService.cs
+++ b/Services/krc_DataService.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using WamisWaterLevelDataApi.Models; // KRC Models
+using WamisWaterLevelDataApi.Services; // For KrcReservoirService if needed, or common utilities
+
+namespace WamisWaterLevelDataApi.Services
+{
+    public class KrcDataService
+    {
+        private readonly string _connectionString;
+        private readonly Action<string> _logAction;
+
+        public KrcDataService(string connectionString, Action<string> logAction = null)
+        {
+            _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+            _logAction = logAction ?? Console.WriteLine;
+        }
+
+        /// <summary>
+        /// KRC 저수지 코드 정보를 stations 테이블에 Upsert 합니다.
+        /// WAMIS의 UpsertStationsAsync를 참고하여 KRC API 응답에 맞게 수정.
+        /// KRC API는 fac_code, fac_name, county를 제공. station_type은 'KRC_RESERVOIR'로 지정.
+        /// </summary>
+        public async Task UpsertKrcReservoirStationsAsync(List<KrcReservoirCodeItem> krcStations)
+        {
+            if (krcStations == null || !krcStations.Any())
+            {
+                _logAction("저장할 KRC 저수지 정보가 없습니다.");
+                return;
+            }
+
+            var stationCodes = new List<string>();
+            var stationNames = new List<string>();
+            var stationTypes = new List<string>(); // KRC 저수지 타입으로 고정
+            // county 정보는 stations 테이블에 직접 저장하지 않음 (필요시 별도 테이블 또는 확장)
+
+            foreach (var station in krcStations)
+            {
+                if (string.IsNullOrWhiteSpace(station.FacCode)) continue;
+
+                stationCodes.Add(station.FacCode);
+                stationNames.Add(station.FacName); // fac_name을 station_name으로 사용
+                stationTypes.Add("KRC_RESERVOIR"); // 고정된 타입
+            }
+
+            if (!stationCodes.Any()) return;
+
+            using (var conn = new NpgsqlConnection(_connectionString))
+            {
+                await conn.OpenAsync();
+                var upsertCommand = @"
+                    INSERT INTO stations (station_code, station_name, station_type)
+                    SELECT * FROM UNNEST(@codes, @names, @types)
+                    ON CONFLICT (station_code) DO UPDATE SET
+                        station_name = EXCLUDED.station_name,
+                        station_type = EXCLUDED.station_type;";
+
+                using (var cmd = new NpgsqlCommand(upsertCommand, conn))
+                {
+                    cmd.Parameters.AddWithValue("codes", stationCodes);
+                    cmd.Parameters.AddWithValue("names", stationNames);
+                    cmd.Parameters.AddWithValue("types", stationTypes);
+                    var affectedRows = await cmd.ExecuteNonQueryAsync();
+                    _logAction($"{affectedRows} (요청된 KRC 저수지 {stationCodes.Count}개 중) KRC 저수지 관측소 정보가 처리/업데이트되었습니다.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// KRC 저수지 일별 수위 및 저수율 데이터를 krc_reservoir_daily 테이블에 Upsert 합니다.
+        /// </summary>
+        public async Task BulkUpsertKrcReservoirDailyDataAsync(List<KrcReservoirLevelItem> levelData)
+        {
+            if (levelData == null || !levelData.Any())
+            {
+                _logAction("저장할 KRC 저수지 수위 데이터가 없습니다.");
+                return;
+            }
+
+            // 중복 제거 및 데이터 변환 (station_code, obs_date 기준)
+            var uniqueData = new Dictionary<(string facCode, DateTime obsDate), (double? waterLevel, double? rate)>();
+
+            foreach (var item in levelData)
+            {
+                if (string.IsNullOrWhiteSpace(item.FacCode) ||
+                    !DateTime.TryParseExact(item.CheckDate, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var obsDate))
+                {
+                    _logAction($"잘못된 데이터 형식 건너뜀: FacCode='{item.FacCode}', CheckDate='{item.CheckDate}'");
+                    continue;
+                }
+
+                double? waterLevel = null;
+                if (double.TryParse(item.WaterLevel, NumberStyles.Any, CultureInfo.InvariantCulture, out var wl))
+                {
+                    waterLevel = wl;
+                }
+
+                double? rate = null;
+                if (double.TryParse(item.Rate, NumberStyles.Any, CultureInfo.InvariantCulture, out var rt))
+                {
+                    rate = rt;
+                }
+
+                uniqueData[(item.FacCode, obsDate.Date)] = (waterLevel, rate);
+            }
+
+            if (!uniqueData.Any())
+            {
+                _logAction("처리할 유효한 KRC 저수지 수위 데이터가 없습니다.");
+                return;
+            }
+
+            var stationCodes = uniqueData.Keys.Select(k => k.facCode).ToList();
+            var obsDates = uniqueData.Keys.Select(k => k.obsDate).ToList();
+            var waterLevels = uniqueData.Values.Select(v => v.waterLevel).ToList();
+            var rates = uniqueData.Values.Select(v => v.rate).ToList();
+
+            using (var conn = new NpgsqlConnection(_connectionString))
+            {
+                await conn.OpenAsync();
+                var commandText = @"
+                    INSERT INTO krc_reservoir_daily (station_code, obs_date, water_level, rate)
+                    SELECT * FROM UNNEST(@station_codes, @obs_dates, @water_levels, @rates)
+                    ON CONFLICT (station_code, obs_date) DO UPDATE SET
+                        water_level = EXCLUDED.water_level,
+                        rate = EXCLUDED.rate;";
+
+                using (var cmd = new NpgsqlCommand(commandText, conn))
+                {
+                    cmd.Parameters.AddWithValue("station_codes", stationCodes);
+                    cmd.Parameters.AddWithValue("obs_dates", obsDates);
+                    cmd.Parameters.AddWithValue("water_levels", waterLevels.Select(wl => wl.HasValue ? (object)wl.Value : DBNull.Value).ToList());
+                    cmd.Parameters.AddWithValue("rates", rates.Select(r => r.HasValue ? (object)r.Value : DBNull.Value).ToList());
+
+                    var affectedRows = await cmd.ExecuteNonQueryAsync();
+                    _logAction($"{affectedRows} (총 {uniqueData.Count}개 항목) KRC 저수지 일별 수위/저수율 데이터가 처리/업데이트되었습니다.");
+                }
+            }
+        }
+    }
+}

--- a/Services/krc_ReservoirService.cs
+++ b/Services/krc_ReservoirService.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using WamisWaterLevelDataApi.Models; // Assuming Models namespace
+
+namespace WamisWaterLevelDataApi.Services
+{
+    public class KrcReservoirService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly string _serviceKey;
+        private const string ReservoirCodeBaseUrl = "http://apis.data.go.kr/B552149/reserviorWaterLevel/reservoircode/";
+        private const string ReservoirLevelBaseUrl = "http://apis.data.go.kr/B552149/reserviorWaterLevel/reservoirlevel/";
+
+        public KrcReservoirService(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _serviceKey = ConfigurationManager.AppSettings["KrcApiKey"];
+            if (string.IsNullOrEmpty(_serviceKey))
+            {
+                // Fallback for environments where App.config might not be easily available (e.g., testing without full config setup)
+                // Or throw an exception if the key is absolutely mandatory.
+                Console.WriteLine("Warning: KrcApiKey not found in App.config. Using placeholder. This should be configured for actual use.");
+                // In a real application, throw new ConfigurationErrorsException("KrcApiKey is not configured in App.config");
+                _serviceKey = "YOUR_KRC_API_KEY_FALLBACK"; // Ensure this key is valid or handle appropriately
+            }
+        }
+
+        private async Task<T> CallApiAsync<T>(string baseUrl, Dictionary<string, string> queryParams) where T : class
+        {
+            var requestUrl = baseUrl + "?" + await new FormUrlEncodedContent(queryParams).ReadAsStringAsync();
+            Console.WriteLine($"Requesting KRC API: {requestUrl}"); // Logging the request URL
+
+            try
+            {
+                HttpResponseMessage response = await _httpClient.GetAsync(requestUrl);
+
+                string xmlData = await response.Content.ReadAsStringAsync();
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    // Try to deserialize as KrcOpenApiErrorResponse first
+                    try
+                    {
+                        KrcOpenApiErrorResponse errorResponse = DeserializeXml<KrcOpenApiErrorResponse>(xmlData);
+                        if (errorResponse != null && errorResponse.CmmMsgHeader != null)
+                        {
+                            throw new HttpRequestException(
+                                $"API Error: {errorResponse.CmmMsgHeader.ErrMsg} (Code: {errorResponse.CmmMsgHeader.ReturnReasonCode}, AuthMsg: {errorResponse.CmmMsgHeader.ReturnAuthMsg}). URL: {requestUrl}");
+                        }
+                    }
+                    catch (InvalidOperationException) // Not an OpenAPIErrorResponse, try KrcHeader style
+                    {
+                        // Try to deserialize as a generic response to get KrcHeader for provider errors
+                        var genericResponse = DeserializeXml<KrcReservoirCodeResponse>(xmlData); // Or any other type that has KrcHeader
+                        if (genericResponse != null && genericResponse.Header != null)
+                        {
+                             throw new HttpRequestException(
+                                $"API Provider Error: {genericResponse.Header.ReturnAuthMsg} (Code: {genericResponse.Header.ReturnReasonCode}). URL: {requestUrl}");
+                        }
+                    }
+                    // If neither deserialization works, throw a generic error with status code
+                    response.EnsureSuccessStatusCode(); // This will throw if not success and not handled above
+                }
+
+                return DeserializeXml<T>(xmlData);
+            }
+            catch (HttpRequestException ex)
+            {
+                Console.WriteLine($"HTTP Request Exception: {ex.Message} for URL: {requestUrl}");
+                throw; // Re-throw to be handled by the caller
+            }
+            catch (InvalidOperationException ex) // Catches XML deserialization errors
+            {
+                Console.WriteLine($"XML Deserialization Exception: {ex.Message} for URL: {requestUrl}");
+                // Consider logging the raw XML (xmlData) here for debugging if it's not too large
+                throw new InvalidOperationException($"Failed to deserialize XML response from KRC API. URL: {requestUrl}. Error: {ex.Message}", ex);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Generic Exception during API call: {ex.Message} for URL: {requestUrl}");
+                throw;
+            }
+        }
+
+
+        // --- 저수지 코드 조회 (reservoircode) ---
+
+        /// <summary>
+        /// 저수지 코드를 조회합니다. fac_name 또는 county 중 하나는 필수입니다.
+        /// </summary>
+        /// <param name="facName">저수지 이름</param>
+        /// <param name="county">저수지 위치 (시/군)</param>
+        /// <param name="numOfRows">한 페이지 결과 수</param>
+        /// <param name="pageNo">페이지 번호</param>
+        /// <returns>KrcReservoirCodeResponse 객체</returns>
+        public async Task<KrcReservoirCodeResponse> GetReservoirCodesAsync(string facName = null, string county = null, int numOfRows = 10, int pageNo = 1)
+        {
+            if (string.IsNullOrWhiteSpace(facName) && string.IsNullOrWhiteSpace(county))
+            {
+                throw new ArgumentException("저수지 이름(facName) 또는 저수지 위치(county) 중 하나는 반드시 입력해야 합니다.");
+            }
+
+            var queryParams = new Dictionary<string, string>
+            {
+                { "serviceKey", _serviceKey },
+                { "numOfRows", numOfRows.ToString() },
+                { "pageNo", pageNo.ToString() }
+            };
+
+            if (!string.IsNullOrWhiteSpace(facName))
+            {
+                queryParams.Add("fac_name", facName);
+            }
+            if (!string.IsNullOrWhiteSpace(county))
+            {
+                queryParams.Add("county", county);
+            }
+
+            var requestUrl = ReservoirCodeBaseUrl + "?" + await new FormUrlEncodedContent(queryParams).ReadAsStringAsync();
+
+            // 실제 API 호출 및 XML 역직렬화 로직 (다음 단계에서 구체화)
+            // HttpResponseMessage response = await _httpClient.GetAsync(requestUrl);
+            // response.EnsureSuccessStatusCode();
+            // string xmlData = await response.Content.ReadAsStringAsync();
+            // return DeserializeXml<KrcReservoirCodeResponse>(xmlData);
+            Console.WriteLine($"Request URL (Reservoir Codes): {requestUrl}");
+            return await Task.FromResult(new KrcReservoirCodeResponse()); // Placeholder
+        }
+
+
+        // --- 저수지 수위 조회 (reservoirlevel) ---
+
+        /// <summary>
+        /// 지정된 저수지 코드와 기간으로 수위 정보를 조회합니다. (초기 데이터 구축용)
+        /// </summary>
+        /// <param name="facCode">저수지 코드</param>
+        /// <param name="dateS">조회 시작 날짜 (YYYYMMDD)</param>
+        /// <param name="dateE">조회 종료 날짜 (YYYYMMDD)</param>
+        /// <param name="county">저수지 위치 (선택 사항, facCode와 함께 사용 가능)</param>
+        /// <param name="numOfRows">한 페이지 결과 수</param>
+        /// <param name="pageNo">페이지 번호</param>
+        /// <param name="isTestMode">테스트 모드 여부</param>
+        /// <returns>KrcReservoirLevelResponse 객체</returns>
+        public async Task<KrcReservoirLevelResponse> GetReservoirLevelsForInitialSetupAsync(
+            string facCode, string dateS, string dateE, string county = null,
+            int numOfRows = 30, int pageNo = 1, bool isTestMode = false)
+        {
+            if (string.IsNullOrWhiteSpace(facCode) && string.IsNullOrWhiteSpace(county))
+            {
+                 throw new ArgumentException("저수지 코드(facCode) 또는 저수지 위치(county) 중 하나는 반드시 입력해야 합니다.");
+            }
+            if (isTestMode)
+            {
+                // 테스트 모드일 경우 목업 데이터 반환 또는 특정 로직 수행
+                Console.WriteLine("[TEST MODE] GetReservoirLevelsForInitialSetupAsync called.");
+                return new KrcReservoirLevelResponse { Body = new KrcReservoirLevelBody { Items = new List<KrcReservoirLevelItem>() }};
+            }
+
+            var queryParams = new Dictionary<string, string>
+            {
+                { "serviceKey", _serviceKey },
+                { "date_s", dateS },
+                { "date_e", dateE },
+                { "numOfRows", numOfRows.ToString() },
+                { "pageNo", pageNo.ToString() }
+            };
+
+            if (!string.IsNullOrWhiteSpace(facCode))
+            {
+                queryParams.Add("fac_code", facCode);
+            }
+            if (!string.IsNullOrWhiteSpace(county))
+            {
+                 queryParams.Add("county", county);
+            }
+
+            var requestUrl = ReservoirLevelBaseUrl + "?" + await new FormUrlEncodedContent(queryParams).ReadAsStringAsync();
+
+            // 실제 API 호출 및 XML 역직렬화 로직 (다음 단계에서 구체화)
+            Console.WriteLine($"Request URL (Initial Setup Reservoir Levels): {requestUrl}");
+            return await Task.FromResult(new KrcReservoirLevelResponse()); // Placeholder
+        }
+
+        /// <summary>
+        /// 최신 저수지 수위 정보를 조회합니다. (실시간 데이터 수집용)
+        /// </summary>
+        /// <param name="facCode">저수지 코드</param>
+        /// <param name="county">저수지 위치 (선택 사항, facCode와 함께 사용 가능)</param>
+        /// <param name="isTestMode">테스트 모드 여부</param>
+        /// <returns>KrcReservoirLevelResponse 객체</returns>
+        public async Task<KrcReservoirLevelResponse> GetRealtimeReservoirLevelsAsync(string facCode, string county = null, bool isTestMode = false)
+        {
+            // 실시간 데이터는 보통 당일 또는 최근 1일 데이터를 의미하므로, date_s와 date_e를 오늘 날짜로 설정
+            string today = DateTime.Now.ToString("yyyyMMdd");
+            // For realtime, typically, we want a small number of results, e.g., the latest single reading.
+            // The KRC API might not directly support "latest", so getting today's data is a common approach.
+            // numOfRows=1 might be appropriate if the API sorts by latest time within the day.
+            // If not, we might need to fetch more and pick the latest. For now, using 10 as a small batch.
+            return await GetReservoirLevelsForInitialSetupAsync(facCode, today, today, county, 10, 1, isTestMode);
+        }
+
+        /// <summary>
+        /// DB에 저장된 마지막 데이터 이후부터 현재까지의 저수지 수위 정보를 조회합니다. (데이터 최신화용)
+        /// </summary>
+        /// <param name="facCode">저수지 코드</param>
+        /// <param name="lastSavedDate">DB에 저장된 마지막 데이터의 날짜 (YYYYMMDD)</param>
+        /// <param name="county">저수지 위치 (선택 사항, facCode와 함께 사용 가능)</param>
+        /// <param name="isTestMode">테스트 모드 여부</param>
+        /// <returns>KrcReservoirLevelResponse 객체</returns>
+        public async Task<KrcReservoirLevelResponse> UpdateReservoirLevelsAsync(string facCode, string lastSavedDate, string county = null, bool isTestMode = false)
+        {
+            if (string.IsNullOrEmpty(lastSavedDate) || lastSavedDate.Length != 8)
+            {
+                throw new ArgumentException("유효한 마지막 저장 날짜(lastSavedDate, YYYYMMDD)를 입력해야 합니다.");
+            }
+
+            DateTime startDateFromDb;
+            if (!DateTime.TryParseExact(lastSavedDate, "yyyyMMdd", null, System.Globalization.DateTimeStyles.None, out startDateFromDb))
+            {
+                throw new ArgumentException("lastSavedDate 형식이 잘못되었습니다. YYYYMMDD 형식이어야 합니다.");
+            }
+
+            DateTime startDateForApi = startDateFromDb.AddDays(1);
+            string dateS = startDateForApi.ToString("yyyyMMdd");
+            string dateE = DateTime.Now.ToString("yyyyMMdd");
+
+            if (startDateForApi > DateTime.Now.Date) // 이미 최신 데이터 (날짜만 비교)
+            {
+                Console.WriteLine($"Data for facCode {facCode} is already up to date (Last saved: {lastSavedDate}). No new data to fetch.");
+                return new KrcReservoirLevelResponse
+                {
+                    Header = new KrcHeader { ReturnReasonCode = "00", ReturnAuthMsg = "NO_DATA_TO_UPDATE (ALREADY_CURRENT)"},
+                    Body = new KrcReservoirLevelBody { Items = new List<KrcReservoirLevelItem>(), TotalCount = 0 }
+                };
+            }
+
+            // KRC API는 저수지별 조회 시 최대 365일
+            // 기간이 365일을 초과하는 경우, 여러 번 호출해야 할 수 있으나,
+            // 이 메소드는 '최신화'이므로, 마지막 저장일로부터 현재까지의 기간이 매우 길지 않다고 가정.
+            // 만약 길다면, 호출하는 쪽에서 분할 호출 전략 필요. 여기서는 단일 호출로 가정.
+            int maxRowsForUpdate = 365; // API 제약조건에 따라 설정
+            return await GetReservoirLevelsForInitialSetupAsync(facCode, dateS, dateE, county, maxRowsForUpdate, 1, isTestMode);
+        }
+
+        private T DeserializeXml<T>(string xmlData) where T : class
+        {
+            if (string.IsNullOrWhiteSpace(xmlData))
+            {
+                Console.WriteLine("XML data is null or whitespace. Cannot deserialize.");
+                return null; // 또는 throw new ArgumentNullException(nameof(xmlData));
+            }
+            try
+            {
+                var serializer = new XmlSerializer(typeof(T));
+                using (var reader = new StringReader(xmlData))
+                {
+                    return serializer.Deserialize(reader) as T;
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Log the XML data that failed to deserialize for easier debugging
+                // Be cautious if XML data can be very large or contain sensitive info before logging.
+                Console.WriteLine($"Error deserializing XML. Data: \n{xmlData}\nError: {ex.ToString()}");
+                throw; // Re-throw the exception to be handled by the caller
+            }
+        }
+    }
+}


### PR DESCRIPTION
KRC API 연동 및 기능 추가 계획
KRC API 가이드 문서를 추가하고, 저수지 코드 및 일일 수위 데이터를 조회하는 서비스를 구현할 예정입니다.

KRC API 응답(XML 형식)에 맞는 모델을 생성할 예정입니다.

API 호출을 담당하는 KrcReservoirService와, 데이터베이스(stations, krc_reservoir_daily 테이블) 연동을 위한 KrcDataService를 구현할 예정입니다.

MainFrm에 KRC 데이터 작업을 위한 UI 요소(버튼, 그룹박스 등)를 추가할 예정입니다.

모든 KRC 저수지 코드를 조회해 'stations' 테이블에 저장

KRC 저수지 수위 데이터의 초기 적재, 일일 갱신, 과거 데이터 백필 기능 구현

API 제한 준수를 위해 장기간 데이터 조회 시 기간 분할 처리 구현

API 인증을 위해 App.config에 KrcApiKey를 추가할 예정입니다.

MainFrm의 KRC 데이터 수집 로직을 리팩터링하여, 진행률 표시(Progress Bar) 업데이트를 개선하고 코드 중복을 줄일 예정입니다.