### PR TITLE
Refactor KRC data storage and update documents

### DIFF
--- a/APItoDB_WAMIS/MainFrm.Designer.cs
+++ b/APItoDB_WAMIS/MainFrm.Designer.cs
@@ -94,15 +94,13 @@
             this._txtLogs.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._txtLogs.Location = new System.Drawing.Point(14, 182);
+            this._txtLogs.Location = new System.Drawing.Point(14, 160);
             this._txtLogs.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this._txtLogs.Multiline = true;
             this._txtLogs.Name = "_txtLogs";
             this._txtLogs.ReadOnly = true;
             this._txtLogs.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-
-
-            this._txtLogs.Size = new System.Drawing.Size(868, 601);
+            this._txtLogs.Size = new System.Drawing.Size(868, 476);
             this._txtLogs.TabIndex = 5;
             // 
             // _progressBar
@@ -151,22 +149,20 @@
             this.groupBoxKRC.Controls.Add(this._btnKrcDailyUpdate);
             this.groupBoxKRC.Controls.Add(this._btnKrcInitialLoad);
             this.groupBoxKRC.Controls.Add(this._btnKrcFetchAllCodes);
-            this.groupBoxKRC.Location = new System.Drawing.Point(14, 115);
+            this.groupBoxKRC.Location = new System.Drawing.Point(14, 100);
             this.groupBoxKRC.Name = "groupBoxKRC";
-            this.groupBoxKRC.Size = new System.Drawing.Size(868, 60);
+            this.groupBoxKRC.Size = new System.Drawing.Size(868, 53);
             this.groupBoxKRC.TabIndex = 11;
             this.groupBoxKRC.TabStop = false;
             this.groupBoxKRC.Text = "KRC 농업용 저수지";
-
-
-
+            //
             // _btnKrcFetchAllCodes
             //
             this._btnKrcFetchAllCodes.Location = new System.Drawing.Point(10, 20);
             this._btnKrcFetchAllCodes.Name = "_btnKrcFetchAllCodes";
-            this._btnKrcFetchAllCodes.Size = new System.Drawing.Size(140, 34);
+            this._btnKrcFetchAllCodes.Size = new System.Drawing.Size(140, 28);
             this._btnKrcFetchAllCodes.TabIndex = 0;
-            this._btnKrcFetchAllCodes.Text = "코드 조회/저장";
+            this._btnKrcFetchAllCodes.Text = "전체 코드 조회/저장";
             this._btnKrcFetchAllCodes.UseVisualStyleBackColor = true;
             this._btnKrcFetchAllCodes.Click += new System.EventHandler(this.BtnKrcFetchAllCodes_Click);
             //
@@ -207,7 +203,7 @@
             this.groupBoxWamis.Controls.Add(this._btnBackfill);
             this.groupBoxWamis.Location = new System.Drawing.Point(14, 45);
             this.groupBoxWamis.Name = "groupBoxWamis";
-            this.groupBoxWamis.Size = new System.Drawing.Size(868, 64);
+            this.groupBoxWamis.Size = new System.Drawing.Size(868, 52);
             this.groupBoxWamis.TabIndex = 12;
             this.groupBoxWamis.TabStop = false;
             this.groupBoxWamis.Text = "WAMIS 수자원";

--- a/APItoDB_WAMIS/W_Services/Wamis_DataService.cs
+++ b/APItoDB_WAMIS/W_Services/Wamis_DataService.cs
@@ -708,7 +708,6 @@ namespace WamisDataCollector.Services
         public async Task<DateTime?> GetLastDailyWaterLevelDateAsync(string stationCode) => await GetLastDateAsync("wl_daily", "obs_date", "station_code", stationCode);
 
         // KRC 저수지 데이터용 마지막 날짜 조회
-
         public async Task<DateTime?> GetLastKrcLevelDailyDateAsync(string facCode) => await GetLastDateAsync("reservoirlevel", "check_date", "fac_code", facCode);
 
         public async Task<DateTime?> GetLastWeatherHourlyDateAsync(string stationCode) => await GetLastDateAsync("weather_hourly", "obs_time", "station_code", stationCode);

--- a/APItoDB_WAMIS/project_md/1.prd.md
+++ b/APItoDB_WAMIS/project_md/1.prd.md
@@ -38,11 +38,11 @@
    33
    34 - **데이터베이스:** 수집된 모든 데이터는 PostgreSQL 데이터베이스에 저장됩니다.
    35 - **테이블 구조:**
-   36     - WAMIS 데이터: 각 데이터 종류 및 주기에 따라 별도의 테이블에 저장 (예: `rf_hourly`, `wl_daily` 등)
+   36     - WAMIS 데이터: 각 데이터 종류 및 주기에 따라 별도의 테이블에 저장 (예: `rf_hourly`, `wl_daily` 등). `stations` 테이블은 WAMIS 관측소 정보 저장.
    37     - KRC 데이터:
-   38         - `stations` 테이블: KRC 저수지 코드 및 이름 저장 (`station_type`으로 "KRC_RESERVOIR" 지정)
-   39         - `krc_reservoir_daily` 테이블: KRC 저수지 일별 수위 및 저수율 데이터 저장
-   40 - **데이터 무결성:** 관측소/저수지 코드와 관측 시간을 기본 키(Primary Key)로 사용하여 데이터 중복을 방지합니다.
+   38         - `krc_reservoircode` 테이블: KRC 저수지 코드, 저수지명, 시군명 등 기본 정보 저장.
+   39         - `reservoirlevel` 테이블: KRC 저수지 일별 수위 및 저수율, 저수지명, 시군명 등 상세 정보 저장.
+   40 - **데이터 무결성:** 각 테이블의 특성에 맞는 기본 키(Primary Key)를 사용하여 데이터 중복을 방지합니다. (예: `krc_reservoircode`의 `fac_code`, `reservoirlevel`의 `fac_code` + `check_date` 복합키)
    41
    42 ### 2.3. 사용자 인터페이스 (UI)
    43

--- a/APItoDB_WAMIS/project_md/2.design.md
+++ b/APItoDB_WAMIS/project_md/2.design.md
@@ -40,29 +40,30 @@
    33  - **`BackfillMissingDataAsync` (WAMIS):** 최근 7일간의 WAMIS 데이터를 다시 수집하여 데이터베이스를 최신 상태로 업데이트하는 프로세스를 관리합니다.
    34
    35 - **KRC 데이터 처리 로직 (`MainFrm.cs` 내 이벤트 핸들러):**
-   36     - **코드 조회/저장:** `KrcReservoirService.GetReservoirCodesAsync`를 호출하여 전체 KRC 저수지 코드를 페이지별로 수집하고, `KrcDataService.UpsertKrcReservoirStationsAsync`를 통해 `stations` 테이블에 저장합니다.
+   36     - **코드 조회/저장:** `KrcReservoirService.GetReservoirCodesAsync`를 호출하여 전체 KRC 저수지 코드를 페이지별로 수집하고, `KrcDataService.UpsertKrcReservoirStationsAsync`를 통해 **`krc_reservoircode`** 테이블에 저장합니다.
    37     - **수위 데이터 수집 (초기/최신화/보충):**
-   38         - `Wamis_DataService.GetAllStationsAsync("KRC_RESERVOIR")`로 DB에서 KRC 저수지 목록을 가져옵니다.
+   38         - `Wamis_DataService.GetKrcReservoirStationInfosAsync()`로 DB의 **`krc_reservoircode`** 테이블에서 KRC 저수지 목록을 가져옵니다.
    39         - 각 저수지 코드에 대해 `KrcReservoirService`의 수위 조회 메소드 (`GetReservoirLevelsForInitialSetupAsync`, `UpdateReservoirLevelsAsync`)를 호출합니다.
    40         - API 호출 시 기간이 KRC API의 최대 조회 기간(365일)을 초과하는 경우, 기간을 분할하여 여러 번 호출합니다.
-   41         - `KrcDataService.BulkUpsertKrcReservoirDailyDataAsync`를 통해 수집된 수위 데이터를 `krc_reservoir_daily` 테이블에 저장합니다.
+   41         - `KrcDataService.BulkUpsertKrcReservoirDailyDataAsync`를 통해 수집된 수위 데이터를 **`reservoirlevel`** 테이블에 저장합니다.
    42
    43 ### 1.3. Data Access Layer
    44
-   45 - **`Wamis_DataService.cs`:** WAMIS 데이터 및 KRC 저수지 코드(`stations` 테이블) 등 공통적인 데이터베이스 상호작용을 담당합니다.
+   45 - **`Wamis_DataService.cs`:** WAMIS 데이터 및 **새로운 KRC 테이블 생성, KRC 저수지 코드/마지막 날짜 조회** 등 공통적인 데이터베이스 상호작용을 담당합니다.
    46 - **역할:**
    47     - `Npgsql` 라이브러리를 사용하여 PostgreSQL 데이터베이스에 연결합니다.
-   48     - `EnsureTablesExistAsync`: 애플리케이션 실행 시 필요한 모든 테이블(WAMIS 및 KRC 관련 테이블 포함)이 존재하는지 확인하고, 없으면 생성합니다.
+   48     - `EnsureTablesExistAsync`: 애플리케이션 실행 시 필요한 모든 테이블(WAMIS 및 **`krc_reservoircode`, `reservoirlevel`** 테이블 포함)이 존재하는지 확인하고, 없으면 생성합니다. (기존 `krc_reservoir_daily` 생성 로직은 제거)
    49     - WAMIS 데이터 모델에 맞는 `Upsert` 메서드를 제공합니다.
-   50     - `GetAllStationsAsync`: 특정 타입의 관측소 정보를 `stations` 테이블에서 조회합니다. (KRC 저수지 코드 조회에 활용)
-   51     - `GetLastKrcReservoirDailyDateAsync`: `krc_reservoir_daily` 테이블에서 특정 저수지의 마지막 데이터 날짜를 조회합니다.
-   52
-   53 - **`Services/KrcDataService.cs`:** KRC 농업용 저수지 관련 데이터의 데이터베이스 상호작용을 담당합니다.
-   54 - **역할:**
-   55     - `UpsertKrcReservoirStationsAsync`: KRC 저수지 코드 정보를 `stations` 테이블에 저장/업데이트합니다. (`station_type`을 'KRC_RESERVOIR'로 지정)
-   56     - `BulkUpsertKrcReservoirDailyDataAsync`: KRC 저수지 일별 수위 및 저수율 데이터를 `krc_reservoir_daily` 테이블에 저장/업데이트합니다.
-   57
-   58 ### 1.4. External Communication
+   50     - `GetKrcReservoirStationInfosAsync`: **`krc_reservoircode`** 테이블에서 KRC 저수지 코드 및 이름 정보를 조회합니다. (신규 추가)
+   51     - `GetLastKrcLevelDailyDateAsync`: **`reservoirlevel`** 테이블에서 특정 KRC 저수지의 마지막 데이터 날짜를 조회합니다. (기존 `GetLastKrcReservoirDailyDateAsync`에서 변경)
+   52     - (참고: `stations` 테이블은 더 이상 KRC 코드 저장에 직접 사용되지 않음)
+   53
+   54 - **`Services/KrcDataService.cs`:** KRC 농업용 저수지 관련 데이터의 데이터베이스 상호작용을 담당합니다.
+   55 - **역할:**
+   56     - `UpsertKrcReservoirStationsAsync`: KRC 저수지 코드 정보를 **`krc_reservoircode`** 테이블에 저장/업데이트합니다.
+   57     - `BulkUpsertKrcReservoirDailyDataAsync`: KRC 저수지 일별 수위 및 저수율 데이터를 **`reservoirlevel`** 테이블에 저장/업데이트합니다. (API 응답의 `fac_name`, `county` 포함)
+   58
+   59 ### 1.4. External Communication
    59
    60 - **`Wamis_ApiClient.cs`:** WAMIS API와의 통신을 담당합니다. (기존과 동일)
    61
@@ -86,24 +87,31 @@
    79 ## 3. 데이터베이스 스키마
    80
    81 - **데이터베이스:** PostgreSQL
-   82 - **테이블 (기존):**
-   83     - `stations`: 관측소 기본 정보 (WAMIS 및 KRC 저수지 코드 저장, `station_type`으로 구분)
+   82 - **테이블 (WAMIS 기존):**
+   83     - `stations`: 관측소 기본 정보 (WAMIS 관측소 코드 저장용, `station_type`으로 구분. KRC 코드는 별도 테이블로 분리)
    84     - `rf_hourly`, `rf_daily`, `rf_monthly`: 강수량 데이터 (시간/일/월별)
    85     - `wl_hourly`, `wl_daily`: 수위 데이터 (시간/일별)
    86     - `weather_hourly`, `weather_daily`: 기상 데이터 (시간/일별)
    87     - `flow_measurements`, `flow_daily`: 유량 데이터 (측정/일별)
-   88 - **테이블 (KRC용 신규 추가):**
-   89     - `krc_reservoir_daily`: KRC 저수지 일별 수위 및 저수율 데이터
-   90         - `station_code` (TEXT, PK)
-   91         - `obs_date` (DATE, PK)
-   92         - `water_level` (REAL)
-   93         - `rate` (REAL) - 저수율
-   94 - **키:**
-   95     - `stations`: `station_code` (PK)
-   96     - `krc_reservoir_daily`: `station_code`, `obs_date` (복합 PK)
-   97     - 기타 WAMIS 테이블은 기존과 동일.
-   98
-   99 ## 4. 설정 및 로깅
+   88 - **테이블 (KRC용 신규):**
+   89     - **`krc_reservoircode`**: KRC 저수지 코드 및 기본 정보
+   90         - `fac_code` (TEXT, PK): 저수지 코드
+   91         - `fac_name` (TEXT): 저수지명
+   92         - `county` (TEXT): 시군명
+   93     - **`reservoirlevel`**: KRC 저수지 일별 수위 및 저수율 데이터
+   94         - `fac_code` (TEXT, PK 일부): 저수지 코드
+   95         - `check_date` (DATE, PK 일부): 측정일 (YYYYMMDD 형식에서 변환)
+   96         - `fac_name` (TEXT): 저수지명 (API 응답에 포함된 값)
+   97         - `county` (TEXT): 시군명 (API 응답에 포함된 값)
+   98         - `water_level` (REAL): 저수지 수위 (m)
+   99         - `rate` (REAL): 저수율 (%)
+  100 - **키:**
+  101     - `stations`: `station_code` (PK)
+  102     - `krc_reservoircode`: `fac_code` (PK)
+  103     - `reservoirlevel`: `fac_code`, `check_date` (복합 PK)
+  104     - 기타 WAMIS 테이블은 기존과 동일.
+  105
+  106 ## 4. 설정 및 로깅
   100
   101 - **`App.config`:**
   102     - 기존 WAMIS 관련 설정 외에 `KrcApiKey` 키 항목을 추가하여 KRC API 인증키를 저장합니다.

--- a/APItoDB_WAMIS/project_md/3.development.md
+++ b/APItoDB_WAMIS/project_md/3.development.md
@@ -26,7 +26,7 @@
    23         - `krc_ReservoirCode.cs`, `krc_ReservoirLevel.cs`, `krc_ErrorResponse.cs`: KRC API XML 응답 구조에 따른 C# 클래스 정의
    24     - **`W_Services/`**: WAMIS 관련 서비스 로직 클래스
    25         - `Wamis_ApiClient.cs`: WAMIS API 클라이언트
-   26         - `Wamis_DataService.cs`: PostgreSQL 데이터베이스 서비스 (WAMIS 데이터 및 KRC `stations` 테이블, `krc_reservoir_daily` 테이블 생성/조회 등 공통 DB 로직 포함)
+   26         - `Wamis_DataService.cs`: PostgreSQL 데이터베이스 서비스 (WAMIS 데이터 및 신규 KRC 테이블 `krc_reservoircode`, `reservoirlevel` 생성/조회 등 공통 DB 로직 포함)
    27         - `Wamis_DataSyncService.cs`: WAMIS 데이터 동기화 서비스
    28     - **`Services/`**: KRC 관련 서비스 로직 클래스 (신규)
    29         - `KrcReservoirService.cs`: KRC API 클라이언트
@@ -59,15 +59,15 @@
    56 #### 3.2.1. WAMIS 및 공통 데이터 서비스 (`Wamis_DataService.cs`)
    57 - 기존 WAMIS 데이터 처리 로직 유지.
    58 - **KRC 지원 확장:**
-   59     - `EnsureTablesExistAsync`: `krc_reservoir_daily` 테이블 생성 로직 추가.
-   60     - `GetAllStationsAsync`: `station_type` 파라미터로 "KRC_RESERVOIR" 타입의 관측소 정보를 `stations` 테이블에서 조회하는 기능 제공.
-   61     - `GetLastKrcReservoirDailyDateAsync`: `krc_reservoir_daily` 테이블에서 특정 KRC 저수지의 마지막 데이터 저장 날짜 조회 기능 추가.
+   59     - `EnsureTablesExistAsync`: 기존 `krc_reservoir_daily` 테이블 생성 구문 제거. 신규 `krc_reservoircode` 및 `reservoirlevel` 테이블 생성 로직 추가.
+   60     - `GetKrcReservoirStationInfosAsync`: `krc_reservoircode` 테이블에서 KRC 저수지 코드 및 이름 정보를 조회하는 기능 신규 추가. (`StationInfo` 모델 활용)
+   61     - `GetLastKrcLevelDailyDateAsync`: `reservoirlevel` 테이블에서 특정 KRC 저수지의 마지막 데이터 저장 날짜를 조회하는 기능으로 변경 (기존 `GetLastKrcReservoirDailyDateAsync` 대체).
    62
    63 #### 3.2.2. KRC 데이터 서비스 (`Services/KrcDataService.cs`)
-   64 - KRC 데이터를 DB에 저장하는 로직 담당.
+   64 - KRC 데이터를 신규 테이블에 저장하는 로직 담당.
    65 - **주요 메소드:**
-   66     - `UpsertKrcReservoirStationsAsync`: KRC 저수지 코드 목록을 `stations` 테이블에 저장/업데이트. `station_type`은 "KRC_RESERVOIR"로 지정.
-   67     - `BulkUpsertKrcReservoirDailyDataAsync`: KRC 저수지 일별 수위 및 저수율 데이터를 `krc_reservoir_daily` 테이블에 저장/업데이트. (날짜 변환, 숫자 파싱, `DBNull` 처리 포함)
+   66     - `UpsertKrcReservoirStationsAsync`: KRC 저수지 코드 목록을 `krc_reservoircode` 테이블에 저장/업데이트.
+   67     - `BulkUpsertKrcReservoirDailyDataAsync`: KRC 저수지 일별 수위 및 저수율 데이터를 `reservoirlevel` 테이블에 저장/업데이트 (API 응답의 `fac_name`, `county` 포함).
    68
    69 ### 3.3. 데이터 동기화 및 UI 로직
    70
@@ -79,18 +79,18 @@
    76 - **서비스 초기화**: `KrcReservoirService` 및 `KrcDataService` 인스턴스화.
    77 - **KRC 저수지 코드 전체 조회/저장 (`BtnKrcFetchAllCodes_Click`):**
    78     - `KrcReservoirService.GetReservoirCodesAsync`를 페이지네이션하며 호출하여 모든 코드 수집.
-   79     - `KrcDataService.UpsertKrcReservoirStationsAsync`로 `stations` 테이블에 저장.
+   79     - `KrcDataService.UpsertKrcReservoirStationsAsync`로 `krc_reservoircode` 테이블에 저장.
    80 - **KRC 수위 데이터 수집 공통 로직 (`CollectKrcLevelDataAsync`):**
    81     - `BtnKrcInitialLoad_Click` 및 `BtnKrcBackfill_Click`에서 호출되는 공통 메소드.
-   82     - `Wamis_DataService.GetAllStationsAsync("KRC_RESERVOIR")`로 DB에서 KRC 저수지 코드 목록 조회.
+   82     - `Wamis_DataService.GetKrcReservoirStationInfosAsync()`로 DB의 `krc_reservoircode` 테이블에서 KRC 저수지 코드 목록 조회.
    83     - 각 코드에 대해 API 호출 함수(Func 대리자)를 실행하여 수위 데이터 조회.
    84     - **기간 분할 처리**: 사용자가 요청한 기간이 KRC API의 최대 조회 기간(365일)을 초과하면, 365일 단위로 분할하여 여러 번 API 호출.
-   85     - `KrcDataService.BulkUpsertKrcReservoirDailyDataAsync`로 DB에 저장.
+   85     - `KrcDataService.BulkUpsertKrcReservoirDailyDataAsync`로 `reservoirlevel` 테이블에 저장.
    86     - 프로그레스 바 업데이트 (`UpdateProgressBar` 메소드 사용).
    87 - **KRC 수위 데이터 일별 최신화 (`BtnKrcDailyUpdate_Click`):**
-   88     - DB에서 KRC 저수지 코드 목록 조회.
-   89     - 각 코드별로 `Wamis_DataService.GetLastKrcReservoirDailyDateAsync`를 통해 마지막 저장일 확인.
-   90     - `KrcReservoirService.UpdateReservoirLevelsAsync`를 호출하여 최신 데이터 수집 및 저장.
+   88     - `Wamis_DataService.GetKrcReservoirStationInfosAsync()`로 DB의 `krc_reservoircode` 테이블에서 KRC 저수지 코드 목록 조회.
+   89     - 각 코드별로 `Wamis_DataService.GetLastKrcLevelDailyDateAsync`를 통해 `reservoirlevel` 테이블의 마지막 저장일 확인.
+   90     - `KrcReservoirService.UpdateReservoirLevelsAsync`를 호출하여 최신 데이터 수집 및 `reservoirlevel` 테이블에 저장.
    91 - **프로그레스 바 업데이트 개선**: `UpdateProgressBar` 메소드를 통해 최대값 설정 및 값 업데이트를 명확히 하여 진행 상태 표시 개선.
    92
    93 ### 3.4. 설정 (`App.config`)


### PR DESCRIPTION
- Code changes:
  - Modified DB schema to use dedicated KRC tables: `krc_reservoircode` and `reservoirlevel`.
  - Updated `Wamis_DataService` to manage schema for new KRC tables and provide methods to fetch KRC station infos and last level data dates from these tables.
  - Updated `KrcDataService` to save KRC code and level data to the new dedicated tables, using API response column names directly.
  - Updated `MainFrm` to use the modified service methods for KRC data operations.

- Document updates (in `project_md`):
  - `1.prd.md`: Updated data storage section to reflect new KRC table structure.
  - `2.design.md`: Detailed new KRC table schemas (`krc_reservoircode`, `reservoirlevel`) and updated Data Access Layer descriptions for `Wamis_DataService` and `KrcDataService`.
  - `3.development.md`: Updated project structure, data service implementation details for KRC, and UI logic descriptions to align with new table usage.
  - `5.manual.md`: No changes as internal storage changes do not directly affect your operation as described.