### PR TITLE
Here's how I've improved the KRC initial data construction feature an…

### DIFF
--- a/APItoDB_WAMIS/K_Services/krc_DataService.cs
+++ b/APItoDB_WAMIS/K_Services/krc_DataService.cs
@@ -141,12 +141,12 @@ namespace KRC_Services.Services
 
                 using (var cmd = new NpgsqlCommand(commandText, conn))
                 {
-                    cmd.Parameters.AddWithValue("fac_codes", facCodes);
-                    cmd.Parameters.AddWithValue("check_dates", obsDates);
-                    cmd.Parameters.AddWithValue("fac_names", facNames.Select(n => (object)n ?? DBNull.Value).ToList());
-                    cmd.Parameters.AddWithValue("counties", counties.Select(c => (object)c ?? DBNull.Value).ToList());
-                    cmd.Parameters.AddWithValue("water_levels", waterLevels.Select(wl => wl.HasValue ? (object)wl.Value : DBNull.Value).ToList());
-                    cmd.Parameters.AddWithValue("rates", rates.Select(r => r.HasValue ? (object)r.Value : DBNull.Value).ToList());
+                    cmd.Parameters.Add(new NpgsqlParameter("fac_codes", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Text) { Value = facCodes });
+                    cmd.Parameters.Add(new NpgsqlParameter("check_dates", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Date) { Value = obsDates });
+                    cmd.Parameters.Add(new NpgsqlParameter("fac_names", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Text) { Value = facNames.Select(n => (object)n ?? DBNull.Value).ToList() });
+                    cmd.Parameters.Add(new NpgsqlParameter("counties", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Text) { Value = counties.Select(c => (object)c ?? DBNull.Value).ToList() });
+                    cmd.Parameters.Add(new NpgsqlParameter("water_levels", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Double) { Value = waterLevels.Select(wl => wl.HasValue ? (object)wl.Value : DBNull.Value).ToList() });
+                    cmd.Parameters.Add(new NpgsqlParameter("rates", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Double) { Value = rates.Select(r => r.HasValue ? (object)r.Value : DBNull.Value).ToList() });
 
                     var affectedRows = await cmd.ExecuteNonQueryAsync();
                     _logAction($"{affectedRows} (총 {uniqueData.Count}개 항목) KRC 저수지 일별 수위/저수율 데이터가 `reservoirlevel` 테이블에 처리/업데이트되었습니다.");

--- a/APItoDB_WAMIS/K_Services/krc_ReservoirService.cs
+++ b/APItoDB_WAMIS/K_Services/krc_ReservoirService.cs
@@ -173,11 +173,17 @@ namespace KRC_Services.Services
             {
                 throw new ArgumentException("저수지 코드(facCode) 또는 저수지 위치(county) 중 하나는 반드시 입력해야 합니다.");
             }
-            if (isTestMode)
-            {
-                Console.WriteLine("[TEST MODE] GetReservoirLevelsForInitialSetupAsync called.");
-                return new KrcReservoirLevelResponse { Body = new KrcReservoirLevelBody { Items = new List<KrcReservoirLevelItem>() } };
-            }
+            // 테스트 모드에서도 API를 호출하도록 다음 if 블록을 주석 처리 또는 제거합니다.
+            // MainFrm.cs에서 이미 테스트 모드 시 단일 지점만 선택하도록 로직이 수정되었으므로,
+            // 이 서비스 메소드는 isTestMode 플래그에 관계없이 실제 API를 호출하도록 합니다.
+            // if (isTestMode)
+            // {
+            //    Console.WriteLine("[TEST MODE] GetReservoirLevelsForInitialSetupAsync called for facCode: " + facCode);
+            //    // 테스트를 위해 API를 호출하되, 매우 작은 양의 데이터를 요청하거나,
+            //    // 또는 여기서는 MainFrm에서 이미 지점 수를 줄였으므로 그대로 진행.
+            //    // 만약 API 호출 자체를 막고 싶다면 이 블록을 활성화.
+            //    // return new KrcReservoirLevelResponse { Body = new KrcReservoirLevelBody { Items = new List<KrcReservoirLevelItem>() } };
+            // }
 
             var queryParams = new Dictionary<string, string>
         {

--- a/APItoDB_WAMIS/MainFrm.cs
+++ b/APItoDB_WAMIS/MainFrm.cs
@@ -383,19 +383,36 @@ namespace WamisDataCollector
                 await RunTask(async () =>
                 {
                     Log($"{taskTitle}을(를) 시작합니다...");
-                    // KRC 저수지 코드 목록을 krc_reservoircode 테이블에서 가져오도록 수정
-                    var krcStations = await _wamisDataService.GetKrcReservoirStationInfosAsync();
-                    if (krcStations == null || !krcStations.Any())
+            var allKrcStations = await _wamisDataService.GetKrcReservoirStationInfosAsync();
+
+            if (allKrcStations == null || !allKrcStations.Any())
                     {
                         Log("DB에 KRC 저수지 코드 정보가 없습니다. 먼저 'KRC 전체 코드 조회/저장'을 실행하세요.");
                         return;
                     }
 
-                    Log($"총 {krcStations.Count}개의 KRC 저수지에 대해 {taskTitle}을(를) 진행합니다.");
+            List<KRC_Services.Models.KrcReservoirStationInfo> stationsToProcess;
+            if (isTestMode)
+            {
+                Log($"[테스트 모드] {taskTitle}을(를) 첫 번째 저수지에 대해서만 진행합니다.");
+                stationsToProcess = allKrcStations.Take(1).ToList();
+                if (!stationsToProcess.Any())
+                {
+                    Log("[테스트 모드] 처리할 저수지가 목록에 없습니다.");
+                    return;
+                }
+                Log($"[테스트 모드] 대상 저수지: {stationsToProcess.First().StationCode} ({stationsToProcess.First().Name})");
+            }
+            else
+            {
+                stationsToProcess = allKrcStations;
+            }
 
-                    for (int i = 0; i < krcStations.Count; i++)
+            Log($"총 {stationsToProcess.Count}개의 KRC 저수지에 대해 {taskTitle}을(를) 진행합니다.");
+
+            for (int i = 0; i < stationsToProcess.Count; i++)
                     {
-                        var station = krcStations[i];
+                var station = stationsToProcess[i];
                         DateTime currentStartDate = startDate;
 
                         while (currentStartDate <= endDate)


### PR DESCRIPTION
…d implemented a test mode:

- In `MainFrm.cs`:
  - I've updated the `CollectKrcLevelDataAsync` method. When test mode (`_chkTestMode`) is active, I'll now collect and process data for only the first reservoir from the complete list retrieved from the database.
  - I've also added logging related to the test mode operation.

- In `KrcDataService.cs`:
  - I've modified the `BulkUpsertKrcReservoirDailyDataAsync` method. When saving water level data to the database, I've explicitly set the NpgsqlDbType for the C# list parameters used in the UNNEST function. This resolves Npgsql type mapping errors (for example, dates are now `Date`, and numerical values are `Double` arrays).

- In `KrcReservoirService.cs`:
  - I've adjusted the `GetReservoirLevelsForInitialSetupAsync` method. I've removed the logic that previously prevented API calls when the `isTestMode` flag was true. Now, following the logic in `MainFrm.cs`, even in test mode, I'll make actual API calls and retrieve data for the selected single point.

These changes allow for end-to-end testing based on real data for a single point when in test mode.