### PR TITLE
Fix: MainFrm.cs 내 krcStations 변수명 오류 수정

### DIFF
--- a/APItoDB_WAMIS/MainFrm.cs
+++ b/APItoDB_WAMIS/MainFrm.cs
@@ -378,7 +378,7 @@ namespace WamisDataCollector
                             Log($"[오류] 저수지 코드 {station.StationCode} 최신화 중 오류: {ex.Message}");
                             log.Error($"KRC 수위 일별 최신화 중 오류 (Station: {station.StationCode})", ex);
                         }
-                        UpdateProgressBar(i + 1, krcStations.Count);
+                        UpdateProgressBar(i + 1, stationsToProcess.Count); // krcStations -> stationsToProcess
                     }
                     Log("KRC 저수지 수위 일별 최신화 완료.");
                 });
@@ -455,7 +455,7 @@ namespace WamisDataCollector
                             string dateS = currentStartDate.ToString("yyyyMMdd");
                             string dateE = currentEndDate.ToString("yyyyMMdd");
 
-                            Log($"({i + 1}/{krcStations.Count}) 저수지 코드: {station.StationCode} ({station.Name}) 데이터 수집 중... ({dateS}~{dateE})");
+                            Log($"({i + 1}/{stationsToProcess.Count}) 저수지 코드: {station.StationCode} ({station.Name}) 데이터 수집 중... ({dateS}~{dateE})"); // krcStations -> stationsToProcess
 
                             try
                             {
@@ -480,7 +480,7 @@ namespace WamisDataCollector
                             }
                             currentStartDate = currentEndDate.AddDays(1);
                         }
-                        UpdateProgressBar(i + 1, krcStations.Count);
+                        UpdateProgressBar(i + 1, stationsToProcess.Count); // krcStations -> stationsToProcess
                     }
                     Log($"{taskTitle} 완료.");
                 });


### PR DESCRIPTION
- BtnKrcDailyUpdate_Click 및 CollectKrcLevelDataAsync 메서드 내부에서 `krcStations`로 잘못 참조된 부분을 올바른 변수명(`stationsToProcess`)으로 수정하여 컴파일 오류 해결.
- 이로써 KRC 관련 기능들의 코드 일관성 및 테스트 모드 지원이 완료됨.